### PR TITLE
feat: Update package name and binary name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-BINARY_NAME=kubectl-view-podsg
+BINARY_NAME=kubectl-sg4pod
 VERSION=dev
 REVISION=none
-LDFLAGS=-ldflags "-X 'github.com/naka-gawa/kubectl-view-podsg/cmd/subcommand.version=$(VERSION)' -X 'github.com/naka-gawa/kubectl-view-podsg/cmd/subcommand.revision=$(REVISION)'"
+LDFLAGS=-ldflags "-X 'github.com/naka-gawa/kubectl-sg4pod/cmd/subcommand.version=$(VERSION)' -X 'github.com/naka-gawa/kubectl-sg4pod/cmd/subcommand.revision=$(REVISION)'"
 
 .PHONY: all build test clean release
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	cmd "github.com/naka-gawa/kubectl-view-podsg/cmd/subcommand"
+	cmd "github.com/naka-gawa/kubectl-sg4pod/cmd/subcommand"
 )
 
 func main() {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	cmd "github.com/naka-gawa/kubectl-view-podsg/cmd/subcommand"
+	cmd "github.com/naka-gawa/kubectl-sg4pod/cmd/subcommand"
 )
 
 func TestRun(t *testing.T) {

--- a/cmd/subcommand/root.go
+++ b/cmd/subcommand/root.go
@@ -8,10 +8,10 @@ var version = "dev"
 var revision = "none"
 
 var rootCmd = &cobra.Command{
-	Use:     "kubectl-view-podsg",
+	Use:     "kubectl-sg4pod",
 	Version: version + "-" + revision,
 	Short:   "A kubectl plugin to view pods and security groups, eni.",
-	Long: `kubectl-view-podsg is a kubectl plugin that allows you to view detailed information about pods,
+	Long: `kubectl-sg4pod is a kubectl plugin that allows you to view detailed information about pods,
 security groups, and ENIs (Elastic Network Interfaces) in your Kubernetes cluster.
 
 This plugin provides various commands to help you inspect and manage your cluster's networking and security configurations.

--- a/cmd/subcommand/version.go
+++ b/cmd/subcommand/version.go
@@ -8,8 +8,8 @@ import (
 func NewVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
-		Short: "Print the version number of kubectl-view-podsg",
-		Long: `The 'version' command displays the current version of the kubectl-view-podsg plugin.
+		Short: "Print the version number of kubectl-sg4pod",
+		Long: `The 'version' command displays the current version of the kubectl-sg4pod plugin.
 It helps in tracking the version you're using, especially when updating or debugging.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Printf("Version: %s\nRevision: %s\n", version, revision)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/naka-gawa/kubectl-view-podsg
+module github.com/naka-gawa/kubectl-sg4pod
 
 go 1.23.2
 


### PR DESCRIPTION
Update the package name and binary name in the Makefile, main.go, and main_test.go files to reflect the new repository name "kubectl-sg4pod". This ensures consistency and clarity throughout the codebase.

Refactor the root command name in the root.go file to "kubectl-sg4pod" as well.

This commit also updates the version command's short description in the version.go file to reflect the new repository name.

Resolves: #5